### PR TITLE
Support custom docker args for weave-plugin

### DIFF
--- a/weave
+++ b/weave
@@ -151,6 +151,7 @@ exec_remote() {
         -e WEAVE_DEBUG \
         -e WEAVE_DOCKER_ARGS \
         -e WEAVEPROXY_DOCKER_ARGS \
+        -e WEAVEPLUGIN_DOCKER_ARGS \
         -e WEAVE_PASSWORD \
         -e WEAVE_PORT \
         -e WEAVE_HTTP_ADDR \
@@ -1742,6 +1743,7 @@ launch_plugin_if_not_running() {
         --restart=always \
         -v /run/docker/plugins:/run/docker/plugins \
         -e WEAVE_HTTP_ADDR \
+        $WEAVEPLUGIN_DOCKER_ARGS \
         $PLUGIN_IMAGE "$@"
     wait_for_status $PLUGIN_CONTAINER_NAME http_call_unix $PLUGIN_CONTAINER_NAME status.sock
     util_op create-plugin-network weave weavemesh


### PR DESCRIPTION
`WEAVEPLUGIN_DOCKER_ARGS` environment variable is used to pass custom args when creating plugin container

Our default docker log-driver is gelf (set via DOCKER_OPTS) and all containers send logs to logstash.
But we want weave logs to stay local and be accessible via `docker logs` command.

There are `WEAVE_DOCKER_ARGS` and `WEAVEPROXY_DOCKER_ARGS` variables, but no variable for plugin container.
